### PR TITLE
FIX #9

### DIFF
--- a/modules/application/src/main/scala/leapfin/lemos/word_matcher/Main.scala
+++ b/modules/application/src/main/scala/leapfin/lemos/word_matcher/Main.scala
@@ -63,7 +63,7 @@ object Main extends App {
         help("help"),
         note(
           """
-            |leapfin.lemos.word_matcher.interpreter.leapfin.lemos.word_matcher.algebra.WordMatcher:
+            |WordMatcher:
             |    Generates pseudo-random streams of characters 
             |    and distributes the task of finding a string 
             |    to a set of workers with a timeout


### PR DESCRIPTION
Now `scala word_matcher.jar --help` will show the project name instead of the FQDN of the Main application.