### PR TITLE
Close #27: Adhere to the expected logic proposed by the client docs

### DIFF
--- a/modules/application/src/main/scala/leapfin/lemos/word_matcher/Main.scala
+++ b/modules/application/src/main/scala/leapfin/lemos/word_matcher/Main.scala
@@ -1,14 +1,16 @@
 package leapfin.lemos.word_matcher
 
 import akka.actor.ActorSystem
+import leapfin.infrastructure.stream.utils.search.logger.domain.MatchResultByThread
 import leapfin.infrastructure.stream.utils.search.logger.interpreter.AsyncLogger
 import leapfin.lemos.word_matcher.interpreter.{Config, WordMatcher}
 
 import java.util.concurrent.Executors
 import scala.collection.immutable.LazyList.continually
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.{Duration, DurationInt}
 import scala.language.postfixOps
+import scala.util.Random
 
 object Main extends App {
 
@@ -28,7 +30,7 @@ object Main extends App {
             else failure("Value <workers> must be between 0 and 64")
           )
           .text(
-            "how many workers will perform the task in parallel"
+            "how many workers will perform the same task in parallel"
           ),
         opt[Int]("padding")
           .valueName("<padding>")
@@ -79,20 +81,60 @@ object Main extends App {
   def word_matcher(config: Config) = {
     implicit val system = ActorSystem("WordMatcher")
     implicit val fixedThreadPool = Executors.newFixedThreadPool(config.workers)
-    implicit val ec = ExecutionContext fromExecutor fixedThreadPool
+    implicit val ec =
+      system.dispatcher // ExecutionContext fromExecutor fixedThreadPool
     // we dont want to pollute the actor system execution context with the tasks performed by the workers
     // ie.: system.dispatcher
 
-    def pseudorandomStreamOfCharacters(N: Int): LazyList[Char] =
+    type Stream = LazyList[Char]
+    def pseudorandomStreamOfCharacters(N: Int): Stream =
       LazyList
         .fill(N)('-')
         .concat(LazyList.from(config.searchWord.iterator))
         .concat(continually('-'))
 
-    new WordMatcher(config, AsyncLogger.start) matchWord (
-      pseudorandomStreamOfCharacters(config.padding),
-      config.searchWord,
-      config.timeout seconds
+    val logger = AsyncLogger.start
+
+    val bound = (config.padding / 2)
+    def random = Random.between(-bound, bound)
+
+    val streams: Seq[Stream] =
+      (1 to config.workers) map (_ =>
+        pseudorandomStreamOfCharacters(
+          config.padding + random
+        )
+      )
+
+    def startProcessing =
+      (stream: Stream, streamIndex: Int) =>
+        new WordMatcher(
+          config.copy(workers = 1),
+          logger = { matchResult =>
+            logger.feed(
+              MatchResultByThread(matchResult, streamIndex)
+            )
+          }
+        ) matchWord (
+          stream,
+          config.searchWord,
+          config.timeout seconds
+        )
+
+    val processAllStreams = Future
+      .sequence(
+        streams.zipWithIndex
+          .map {
+            case (stream, index) => Future { startProcessing(stream, index) }
+          }
+      )
+
+    Await.result(
+      for {
+        done <- processAllStreams
+      } yield {
+        logger.printSummarization
+      },
+      Duration.Inf
     )
 
     fixedThreadPool.shutdown()

--- a/modules/application/src/test/scala/leapfin/lemos/word_matcher/spec/WordMatcherSpec.scala
+++ b/modules/application/src/test/scala/leapfin/lemos/word_matcher/spec/WordMatcherSpec.scala
@@ -1,7 +1,7 @@
 package leapfin.lemos.word_matcher.spec
 
 import akka.actor.ActorSystem
-import leapfin.infrastructure.stream.utils.search.logger.interpreter.SuccessLoger
+import leapfin.infrastructure.stream.utils.search.logger.domain.MatchResultByThread
 import leapfin.lemos.word_matcher.algebra
 import leapfin.lemos.word_matcher.interpreter.{Config, WordMatcher}
 
@@ -11,10 +11,7 @@ object WordMatcherSpec {
 }
 class WordMatcherSpec
     extends algebra.WordMatcherSpec(
-      new WordMatcher(
-        config = Config(),
-        logger = new SuccessLoger
-      )(
+      new WordMatcher(config = Config(), logger = _ => ())(
         WordMatcherSpec.system,
         WordMatcherSpec.executionContext
       )

--- a/modules/infrastructure/src/main/scala/leapfin/infrastructure/stream/utils/search/logger/interpreter/AsyncLogger.scala
+++ b/modules/infrastructure/src/main/scala/leapfin/infrastructure/stream/utils/search/logger/interpreter/AsyncLogger.scala
@@ -45,7 +45,9 @@ object AsyncLogger {
         }
 
       case PrintToConsole =>
-        writeStatuses(statuses.values)
+        writeStatuses(
+          statuses.values
+        )
 
     }
   }

--- a/modules/infrastructure/src/main/scala/leapfin/lemos/word_matcher/interpreter/WordMatcher.scala
+++ b/modules/infrastructure/src/main/scala/leapfin/lemos/word_matcher/interpreter/WordMatcher.scala
@@ -2,7 +2,6 @@ package leapfin.lemos.word_matcher.interpreter
 
 import akka.actor.ActorSystem
 import leapfin.infrastructure.stream.utils.search.SlidingWindowSearch
-import leapfin.infrastructure.stream.utils.search.SlidingWindowSearch._
 import leapfin.infrastructure.stream.utils.search.logger.algebra.Logger
 import leapfin.infrastructure.stream.utils.search.logger.interpreter.SuccessLoger
 import leapfin.lemos.word_matcher.Status
@@ -15,7 +14,7 @@ import scala.language.postfixOps
 
 class WordMatcher(
     config: Config,
-    logger: Logger = new SuccessLoger
+    logger: MatchResult => Unit
 )(implicit system: ActorSystem, ec: ExecutionContext)
     extends WordMatcherContract {
 
@@ -34,12 +33,7 @@ class WordMatcher(
       predicate = _.map(_._1).mkString == searchWord,
       stream,
       timeout
-    ) match {
-      case Left(value) =>
-        Left(Status.NotFound(value.byteCount))
-      case Right(value) =>
-        Right(Status.Success(value.elapsedTime, value.byteCount))
-    }
+    )
   }
 
 }

--- a/modules/infrastructure/src/test/scala/leapfin/lemos/word_matcher/spec/WordMatcherSpec.scala
+++ b/modules/infrastructure/src/test/scala/leapfin/lemos/word_matcher/spec/WordMatcherSpec.scala
@@ -14,7 +14,7 @@ class WordMatcherSpec
     extends algebra.WordMatcherSpec(
       new WordMatcher(
         config = Config(),
-        logger = new SuccessLoger
+        logger = matchResult => ()
       )(
         WordMatcherSpec.system,
         WordMatcherSpec.executionContext


### PR DESCRIPTION
The logic goes as following:

generate 10 random streams
process them in parallel
retrieve results
Currently the logic is:

generate 1 random stream
process the stream in parallel by 10 workers
retrieve results