### PR TITLE
Close #32: Add average time of completion for successful workers as the last line of output

### DIFF
--- a/modules/infrastructure/src/main/scala/leapfin/infrastructure/stream/utils/search/logger/interpreter/AsyncLogger.scala
+++ b/modules/infrastructure/src/main/scala/leapfin/infrastructure/stream/utils/search/logger/interpreter/AsyncLogger.scala
@@ -56,6 +56,13 @@ object AsyncLogger {
             .reverse
         )
 
+        print(
+          s"${statuses.values.collect {
+            case Status.Success(elapsedTime, byteCount) =>
+              (byteCount.toDouble / 1000) / elapsedTime.toSeconds
+          }.sum / statuses.values.toSeq.length} MB/s was the average speed per worker"
+        )
+
     }
   }
 


### PR DESCRIPTION
![Screenshot from 2021-06-15 10-32-09](https://user-images.githubusercontent.com/9152392/122011619-f608fb80-cdc4-11eb-98ce-76aa8a9fc2b5.png)
